### PR TITLE
Update Hoxy, add HTTPS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ build
 package
 node_modules
 binaries
-.idea/
-*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 package
 node_modules
 binaries
+.idea/
+*.iml

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/uxebu/james.git"
   },
   "dependencies": {
-    "hoxy": "^1.2.4",
+    "hoxy": "^3.1.3",
     "karma-chrome-launcher": "^0.2.0",
     "nedb": "^1.1.2",
     "pem": "^1.7.2",

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import remote from 'remote';
 import openBrowser from './util/open-browser.js';
 
 const app = remote.require('app');
+const fs = remote.require('fs');
 
 createMenu();
 
@@ -38,7 +39,16 @@ const urlMapper = new UrlMapper(db, function() {
 });
 
 const createHoxy = () => {
-  return new hoxy.Proxy().listen(config.proxyPort);
+  const opts = {};
+  try {
+    const key = fs.readFileSync('./root-ca.key.pem');
+    const cert = fs.readFileSync('./root-ca.crt.pem');
+    opts.certAuthority = {key, cert};
+  } catch (e) {
+    console.log('Not proxying HTTPS, missing key or certificate: ' + e); // eslint-disable-line
+  }
+
+  return hoxy.createServer(opts).listen(config.proxyPort);
 };
 
 const isCachingEnabled = () => {

--- a/test/unit/service/proxy-spec.js
+++ b/test/unit/service/proxy-spec.js
@@ -56,9 +56,7 @@ describe('Proxy', function() {
 
     let requestCount = 0;
 
-    generateRequest = (callback) => {
-      callback = callback || function() {
-      };
+    generateRequest = () => {
       const id = 'url' + requestCount++;
       const request = {
         fullUrl: function() {
@@ -78,13 +76,13 @@ describe('Proxy', function() {
 
       const response = request;
       callbacksRequest.forEach((cb) => {
-        cb.call(cycle, request, response, callback);
+        cb(request, response, cycle);
       });
       callbacksResponse.forEach((cb) => {
-        cb.call(cycle, request, response, callback);
+        cb(request, response, cycle);
       });
       callbacksResponseSent.forEach((cb) => {
-        cb.call(cycle, request, response, callback);
+        cb(request, response, cycle);
       });
 
       return request;
@@ -238,15 +236,6 @@ describe('Proxy', function() {
     });
     it('registers a callback to intercept responses', function() {
       expect(hoxyInstanceMock.intercept).toHaveBeenCalledWith('response');
-    });
-
-    describe('intercept request', function() {
-      it('calls the callback', function() {
-        const callback = sinon.spy();
-        generateRequest(callback);
-
-        expect(callback).toHaveBeenCalled();
-      });
     });
   });
 


### PR DESCRIPTION
Also fixes tests to match new hoxy API

Currently, will enable HTTPS part of proxy only if "root-ca" cert and key files available in current directory. There's no fancy UI or anything, but hey, it's progress :)